### PR TITLE
Fix version file URL property

### DIFF
--- a/AtomicTech/ThermalPond.version
+++ b/AtomicTech/ThermalPond.version
@@ -1,6 +1,6 @@
 {
   "NAME": "MOTHS",
-  "URL": "https://github.com/M.O.T.H.S./raw/main/AtomicTech/ThermalPond.version",
+  "URL": "https://github.com/AtomikkuSan/M.O.T.H.S./raw/main/AtomicTech/ThermalPond.version",
   "DOWNLOAD": "https://github.com/AtomikkuSan/M.O.T.H.S./releases",
   "GITHUB": {
     "USERNAME": "AtomikkuSan",


### PR DESCRIPTION
Hi @AtomikkuSan,

The account name is missing, now it's fixed.

Noticed while reviewing KSP-CKAN/NetKAN#9016.